### PR TITLE
Reimplement in a proper way

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 
 ## How to use it
 
-Put your common configurations in an empty repository or npm module. In the `package.json` of that repo, 
-add the key `commonpkgShare`. Add your common configurations under this key. For example...
+Publish your common configurations as an npm module. In the `package.json` of that module, 
+add the key `commonpkgShare`. Add any `package.json` properties you want to share 
+under this key. For example...
 
 ```json
 {
   "name": "my-common-config",
-  "version": "1.0.6",
+  "version": "1.0.0",
   "description": "Common configurations for MyProject repos",
   "repository": "https://github.com/my-project/common-config",
   "license": "Unlicense",
@@ -37,16 +38,13 @@ add the key `commonpkgShare`. Add your common configurations under this key. For
 }
 ```
 
-Now to share these configurations in your other packages, do the following:
+Now in the package where you want to inherit these configurations, do the following:
 
-#### Add your common configurations package as a dependency:
+#### Add your common configurations as a dependency:
 
 ```
-npm install my-github-username/my-common-config --save-dev
+npm install my-common-config --save-dev
 ```
-
-(With npm, you can install packages directly from GitHub. `my-github-username/my-common-config` is the 
-the repo where you keep your common configs)
 
 #### Install *commonpkg*
 
@@ -54,11 +52,11 @@ the repo where you keep your common configs)
 npm install commonpkg --save-dev
 ```
 
-#### Configure the `package.json` where you want to inherit common properties
+#### Configure the `package.json`
 
 1. Tell *commonpkg* the name of the package that has your configurations. You do that by adding the key `commonpkg` to
 the root of your `package.json`.
-1. Add `commonpkg` to your npm scripts, which you will use to run the *commonpkg* script
+1. Add `commonpkg` to your npm scripts. You will use `npm run commonpkg` to run the *commonpkg* script
 
 For example...
 
@@ -73,9 +71,9 @@ For example...
   "scripts": {
     "commonpkg": "commonpkg" // <== add a script like this
   },
-  "commonpkg": "my-common-config", // <== this key
+  "commonpkg": "my-common-config", // <== add this key to point to the package that has the configs
   "devDependencies": {
-    "my-common-config": "my-github-username/my-common-config",
+    "my-common-config": "^1.0.0",
     "commonpkg": "^2.0.0"
   }
 }
@@ -103,7 +101,7 @@ current `package.json`. After the merge, your `package.json` will look like this
   },
   "commonpkg": "my-common-config",
   "devDependencies": {
-    "my-common-config": "my-github-username/my-common-config",
+    "my-common-config": "^1.0.0",
     "commonpkg": "^2.0.0",
     "lint-staged": "^3.4.0",
     "ts-node": "^3.0.3",
@@ -122,7 +120,10 @@ current `package.json`. After the merge, your `package.json` will look like this
 ```
 
 If the dependencies between your old `package.json` and new `package.json` are different. *commonpkg* will remind
-you to reinstall your `node_modules`.
+you to reinstall your `node_modules`. 
+
+You can do `npm run commonpkg` whenever your common configurations
+change and *commonpkg* will pull in the updates.
 
 ## Bonus tip
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ the root of your `package.json`.
 
 For example...
 
-```json
+```js
 {
   "name": "package-where-i-wanna-import-some-configs",
   "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,32 +6,36 @@
   "repository": "https://github.com/hollowverse/commonpkg",
   "license": "Unlicense",
   "scripts": {
-    "postinstall": "node lib/index.js",
     "preversion": "npm run build",
     "build": "node_modules/.bin/tsc",
     "build/dev": "node_modules/.bin/tsc --watch",
     "lint": "tslint '**/*.t{s,sx}' -e '**/node_modules/**' --fix",
     "precommit": "lint-staged"
   },
+  "bin": {
+    "commonpkg": "lib/index.js"
+  },
   "dependencies": {
-    "lodash.defaultsdeep": "^4.6.0",
     "lodash.get": "^4.4.2",
+    "lodash.merge": "^4.6.0",
     "lodash.pick": "^4.4.0",
     "shelljs": "^0.7.7"
   },
   "devDependencies": {
-    "commonpkg": "^1.0.0",
     "@hollowverse/common-config": "hollowverse/common-config",
     "@types/lodash.defaultsdeep": "^4.6.2",
     "@types/lodash.get": "^4.4.2",
+    "@types/lodash.merge": "^4.6.2",
     "@types/lodash.pick": "^4.4.2",
     "@types/shelljs": "^0.7.1",
+    "commonpkg": "^1.0.0",
     "husky": "^0.13.3",
     "lint-staged": "^3.4.0",
+    "ts-node": "^3.0.3",
     "tslint": "^5.0.0",
     "tslint-config-standard": "^5.0.2",
     "typescript": "^2.1.6",
-    "ts-node": "^3.0.3"
+    "tslint-react": "^3.0.0"
   },
   "commonpkg": "@hollowverse/common-config",
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "preversion": "npm run build",
     "build": "node_modules/.bin/tsc",
     "build/dev": "node_modules/.bin/tsc --watch",
-    "lint": "tslint '**/*.t{s,sx}' -e '**/node_modules/**' --fix",
-    "precommit": "lint-staged"
+    "precommit": "lint-staged",
+    "commonpkg": "commonpkg",
+    "lint": "tslint '**/*.t{s,sx}' -e '**/node_modules/**' --fix --project ./tsconfig.json --type-check"
   },
   "bin": {
     "commonpkg": "lib/index.js"
@@ -22,20 +23,20 @@
     "shelljs": "^0.7.7"
   },
   "devDependencies": {
+    "commonpkg": "^1.0.0",
     "@hollowverse/common-config": "hollowverse/common-config",
     "@types/lodash.defaultsdeep": "^4.6.2",
     "@types/lodash.get": "^4.4.2",
     "@types/lodash.merge": "^4.6.2",
     "@types/lodash.pick": "^4.4.2",
     "@types/shelljs": "^0.7.1",
-    "commonpkg": "^1.0.0",
     "husky": "^0.13.3",
     "lint-staged": "^3.4.0",
     "ts-node": "^3.0.3",
     "tslint": "^5.0.0",
     "tslint-config-standard": "^5.0.2",
-    "typescript": "^2.1.6",
-    "tslint-react": "^3.0.0"
+    "tslint-react": "^3.0.0",
+    "typescript": "^2.1.6"
   },
   "commonpkg": "@hollowverse/common-config",
   "lint-staged": {

--- a/src/dependenciesDiffer.ts
+++ b/src/dependenciesDiffer.ts
@@ -30,7 +30,7 @@ export function dependenciesDiffer(
       for (let key in userNewProperty) {
         if (userNewProperty.hasOwnProperty(key)) {
           // If the new property doesn't exist on the current `package.json`, return true
-          if (!userProperty[key]) {
+          if (userProperty[key] !== userNewProperty[key]) {
             return true
           }
         }

--- a/src/dependenciesDiffer.ts
+++ b/src/dependenciesDiffer.ts
@@ -1,17 +1,14 @@
-type AnyObject = { [key: string]: any }
+interface IAnyObject { [key: string]: any }
 
 export function dependenciesDiffer(
-  userPackageJson: AnyObject,
-  userNewPackageJson: AnyObject,
+  userPackageJson: IAnyObject,
+  userNewPackageJson: IAnyObject,
 ) {
   // Define the properties to compare
   const propertiesToCompare = ['dependencies', 'devDependencies', 'peerDependencies']
 
   // Iterate through the properties to compare them
-  for (let i = 0; i < propertiesToCompare.length; i++) {
-    // Get one property at a time
-    const propertyToCompare = propertiesToCompare[i]
-
+  for (const propertyToCompare of propertiesToCompare) {
     // Look for the property in the user's existing `package.json`
     const userProperty = userPackageJson[propertyToCompare]
 
@@ -27,7 +24,7 @@ export function dependenciesDiffer(
     // If there's a new property that exists on the current `package.json`,
     // let's iterate through its keys and verify that they all exist in the current `package.json`
     if (userNewProperty) {
-      for (let key in userNewProperty) {
+      for (const key in userNewProperty) {
         if (userNewProperty.hasOwnProperty(key)) {
           // If the new property doesn't exist on the current `package.json`, return true
           if (userProperty[key] !== userNewProperty[key]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,6 @@ fs.writeFileSync(userPackageJsonPath, `${JSON.stringify(userNewPackageJson, null
 
 if (requiresNewInstall) {
   console.log(
-    '❗commonpkg has added new dependencies to your `package.json`. You need to reinstall your `node_modules`',
+    '❗commonpkg has modified the dependencies in your `package.json`. You need to reinstall your `node_modules`',
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs'
 import {dependenciesDiffer} from './dependenciesDiffer'
 
 // the following modules don't support ES6 module import, gotta use legacy import syntax
-import pick = require('lodash.pick')
 import get = require('lodash.get')
 import merge = require('lodash.merge')
 
@@ -20,6 +19,6 @@ fs.writeFileSync(userPackageJsonPath, `${JSON.stringify(userNewPackageJson, null
 
 if (requiresNewInstall) {
   console.log(
-    '❗: commonpkg has added new dependencies to your `package.json`. You need to reinstall your `node_modules`',
+    '❗commonpkg has added new dependencies to your `package.json`. You need to reinstall your `node_modules`',
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,98 +1,25 @@
 #!/usr/bin/env node
-import * as shelljs from 'shelljs'
 import * as fs from 'fs'
-import * as path from 'path'
 import {dependenciesDiffer} from './dependenciesDiffer'
 
 // the following modules don't support ES6 module import, gotta use legacy import syntax
 import pick = require('lodash.pick')
 import get = require('lodash.get')
-import defaults = require('lodash.defaultsdeep')
-
-// This process should start at `node_modules/commonpkg/`.
-// If we go one level up, we should be in `node_modules`
-shelljs.cd('..')
-
-if (
-  // Don't re-run the script if it was already run by `commonpkg` previously in the same process
-  process.env.commonpkgInstall === 'attempted' ||
-
-  // Also don't run the script if we're not inside `node_modules` at this point because that
-  // means this repo is running this script because we did `npm install` inside commonpkg repo
-  process.cwd().split(path.sep).pop() !== 'node_modules'
-) {
-  shelljs.exit(0)
-}
-
-// If we go one more level up, we'll be at the desired location: the User Package that depends on
-// commonpkg.
-shelljs.cd('..')
+import merge = require('lodash.merge')
 
 const pwd = process.cwd()
 const userPackageJsonPath = `${pwd}/package.json`
 const userPackageJson = require(userPackageJsonPath)
-
-// Use Yarn if `yarn.lock` exists in the repo. Otherwise use npm.
-const packageManager = fs.existsSync(`${pwd}/yarn.lock`) ? 'yarn' : 'npm'
-
-// Get the name of the Common Package
-const theCommonPackageName = userPackageJson.commonpkg || userPackageJson.commonPackage
-
-let theCommonPackagePackageJson
-let theCommonPackageExists = true
-
-// Check if theCommonPackage has been installed by the package manager
-try {
-  theCommonPackagePackageJson = require(`${theCommonPackageName}/package.json`)
-} catch (e) {
-  theCommonPackageExists = false
-}
-
-if (!theCommonPackageExists) {
-  // If we're here, that means the theCommonPackage hasn't been installed yet.
-  // We need to install it before we can proceed.
-
-  const theCommonPackageVersion = (
-    get(userPackageJson, `devDependencies.${theCommonPackageName}`) ||
-    get(userPackageJson, `dependencies.${theCommonPackageName}`)
-  )
-
-  // At this point we have the data that we need about the Common Package. We can use
-  // the package manager of the repo to install it.
-  const installCommand = packageManager === 'yarn' ? 'add' : 'install'
-
-  shelljs.exec(
-    `${packageManager} ${installCommand} ${theCommonPackageName}@${theCommonPackageVersion}`,
-  )
-
-  // Now that we've installed the common package, let's try to grab its `package.json` again
-  theCommonPackagePackageJson = require(`${theCommonPackageName}/package.json`)
-}
-
-// At this point we hopefully have the Common Package. Let's check which parts of it are to be shared
-const shareablePartsNames = theCommonPackagePackageJson.commonpkgShare
-
-// If we couldn't find any shared parts, let's inform the consumer of the package.
-if (!Array.isArray(shareablePartsNames)) {
-  throw new Error(
-    'commonpkg: the `package.json` of your Common Package is missing the `commonpkgShare` field.',
-  )
-}
-
-// Get the shared parts as a JSON object.
-const shareableProperties = pick(theCommonPackagePackageJson, shareablePartsNames)
-
-// Merge the shared parts with the `package.json` of the User Package.
-const userNewPackageJson = defaults({}, userPackageJson, shareableProperties)
-
-// Let's check if the dependencies of the two `package.json` files differ to determine
-// whether we'll need to perform a new install or not.
+const theCommonPackageName = userPackageJson.commonpkg
+const theCommonPackagePackageJson = require(`${theCommonPackageName}/package.json`)
+const sharedProperties = theCommonPackagePackageJson.commonpkgShare
+const userNewPackageJson = merge({}, userPackageJson, sharedProperties)
 const requiresNewInstall = dependenciesDiffer(userPackageJson, userNewPackageJson)
 
-// Write the new `package.json` to the User Package.
 fs.writeFileSync(userPackageJsonPath, `${JSON.stringify(userNewPackageJson, null, 2)}\n`)
 
-// Do another install with the new dependencies if necessary
 if (requiresNewInstall) {
-  shelljs.exec(`commonpkgInstall=attempted ${packageManager} install`)
+  console.log(
+    '❗: commonpkg has added new dependencies to your `package.json`. You need to reinstall your `node_modules`',
+  )
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,8 @@
 {
   "extends": "@hollowverse/common-config/tslint.json",
   "rules": {
-    "no-require-imports": false
+    "no-require-imports": false,
+    "no-console": false,
+    "no-var-requires": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,12 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.merge@^4.6.2":
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.2.tgz#0f342234744a899748808412fbd39c150cab2da4"
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.pick@^4.4.2":
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@types/lodash.pick/-/lodash.pick-4.4.2.tgz#4a8966d7e19d8f82b2f9c04d900f9eb6c3551861"
@@ -430,6 +436,10 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
+lodash.merge@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
 lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
@@ -464,17 +474,13 @@ make-error@^1.1.1:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimist@0.0.8:
+minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mkdirp@^0.5.1:
   version "0.5.1"
@@ -744,6 +750,10 @@ tslint-eslint-rules@^4.0.0:
     doctrine "^0.7.2"
     tslib "^1.0.0"
     tsutils "^1.4.0"
+
+tslint-react@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tslint-react/-/tslint-react-3.0.0.tgz#00c48ab7f22e91533b62bdef2c162b49447af00a"
 
 tslint@^5.0.0:
   version "5.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,7 +4,7 @@
 
 "@hollowverse/common-config@hollowverse/common-config":
   version "1.0.6"
-  resolved "https://codeload.github.com/hollowverse/common-config/tar.gz/c69dbf7cc39ff5e74e0e950df3f531d5abdac999"
+  resolved "https://codeload.github.com/hollowverse/common-config/tar.gz/8d42f2e902985c550d8e12f0eb0e39a3e7294a58"
 
 "@types/lodash.defaultsdeep@^4.6.2":
   version "4.6.2"
@@ -35,8 +35,8 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.64.tgz#979cf3a3d4a368670840bf9b3e448dc33ffe84ee"
 
 "@types/node@*":
-  version "7.0.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.18.tgz#cd67f27d3dc0cfb746f0bdd5e086c4c5d55be173"
+  version "7.0.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.21.tgz#22a890f19b26cff9b6699b493dea1bcee4410da1"
 
 "@types/shelljs@^0.7.1":
   version "0.7.1"
@@ -82,7 +82,7 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
-brace-expansion@^1.0.0:
+brace-expansion@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
   dependencies:
@@ -135,10 +135,9 @@ commander@^2.9.0:
     graceful-readlink ">= 1.0.0"
 
 commonpkg@^1.0.0:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/commonpkg/-/commonpkg-1.5.3.tgz#9ac4ca124f3da3008727a612224759285b0f536e"
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/commonpkg/-/commonpkg-1.5.5.tgz#857834212bf63b09f79bcdd55726437dde554c93"
   dependencies:
-    commonpkg "^1.0.0"
     lodash.defaultsdeep "^4.6.0"
     lodash.get "^4.4.2"
     lodash.pick "^4.4.0"
@@ -170,8 +169,8 @@ cross-spawn@^5.0.1:
     which "^1.2.9"
 
 date-fns@^1.27.2:
-  version "1.28.4"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.4.tgz#7938aec34ba31fc8bd134d2344bc2e0bbfd95165"
+  version "1.28.5"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
 diff@^3.1.0, diff@^3.2.0:
   version "3.2.0"
@@ -252,13 +251,13 @@ get-stream@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 glob@^7.0.0, glob@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.2"
+    minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -363,15 +362,15 @@ js-tokens@^3.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
 js-yaml@^3.4.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.3.tgz#33a05ec481c850c8875929166fe1beb61c728766"
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
   dependencies:
     argparse "^1.0.7"
     esprima "^3.1.1"
 
 lint-staged@^3.4.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-3.4.1.tgz#96cd1cf7a1ac92d81662643c37d1cca28b91b046"
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-3.4.2.tgz#9cd1c0e4e477326c2696802a8377c22f92d65e79"
   dependencies:
     app-root-path "^2.0.0"
     cosmiconfig "^1.1.0"
@@ -468,11 +467,11 @@ make-error@^1.1.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.2.3.tgz#6c4402df732e0977ac6faf754a5074b3d2b1d19d"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
-    brace-expansion "^1.0.0"
+    brace-expansion "^1.1.7"
 
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
@@ -516,7 +515,7 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -620,8 +619,8 @@ restore-cursor@^1.0.1:
     onetime "^1.0.0"
 
 rxjs@^5.0.0-beta.11:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.3.1.tgz#9ecc9e722247e4f4490d30a878577a3740fd0cb7"
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.0.tgz#a7db14ab157f9d7aac6a56e655e7a3860d39bf26"
   dependencies:
     symbol-observable "^1.0.1"
 
@@ -734,8 +733,8 @@ tsconfig@^6.0.0:
     strip-json-comments "^2.0.0"
 
 tslib@^1.0.0, tslib@^1.6.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.0.tgz#6e8366695f72961252b35167b0dd4fbeeafba491"
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
 
 tslint-config-standard@^5.0.2:
   version "5.0.2"
@@ -771,8 +770,8 @@ tslint@^5.0.0:
     tsutils "^1.8.0"
 
 tsutils@^1.4.0, tsutils@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.8.0.tgz#bf8118ed8e80cd5c9fc7d75728c7963d44ed2f52"
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
 
 typescript@^2.1.6:
   version "2.3.2"
@@ -807,5 +806,7 @@ yallist@^2.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yn@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-1.2.0.tgz#d237a4c533f279b2b89d3acac2db4b8c795e4a63"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-1.3.0.tgz#1b0812abb8d805d48966f8df385dc9dacc9a19d8"
+  dependencies:
+    object-assign "^4.1.1"


### PR DESCRIPTION
I tried to make commonpkg be a set-and-forget type of solution. I wanted it to do its magic automatically after the user does `npm install` or `yarn install` and it sorta worked, but still wasn't really ideal. It broke the `yarn.lock` file in a subtle way that kept me up at night 🌌

I asked a question on StackOverflow and even gave a bounty of 100 points on [my question](http://stackoverflow.com/q/43859388/604296) to figure out a solution, but nothing came out of it.

That's why I'm changing the implementation. The new implementation is *way* simpler, but it's not set-and-forget 🤖

With the new implementation, whenever we want to pull in the latest changes from the common-config package, we have to run `npm run commonpkg`, er, `yarn commonpkg`. I don't think that's too bad, and at least it's not hacky.

@levsthings You don't have to review this PR if you don't want to. I just submitted it as an FYI. Please approve it when you get a chance.